### PR TITLE
fix for free list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+*.o
+sysv/*.cmd
+sysv/modules.order
+sysv/sysv.mod
+sysv/sysv.mod.c
+
+# binaries
+s4date
+s4disk
+s4dump
+s4export
+s4fs
+s4fsck
+s4import
+s4merge
+s4mkfs
+s4test
+s4vol
+libs4.a
+sysv/built-in.a
+sysv/sysv.ko
+

--- a/README.md
+++ b/README.md
@@ -1,28 +1,15 @@
 Fork
 ====
-This is a fork of https://github.com/dgesswein/s4-3b1-pc7300,
-which in turn
-is a fork of https://github.com/dad4x/s4-3b1-pc7300, with fixes
-to work with his images of 3b1 disk drives.
+This is a fork of https://github.com/dad4x/s4-3b1-pc7300 with fixes
+to work with my images of 3b1 disk drives.
 
-So far this fork has updated the `sysv` driver to work on more
-modern Linux systems, in particular on Ubuntu 18.04.  I (Arnold Robbins)
-have added a README.md file there with more information.
+Arnold Robbins has updated the `sysv` driver to work on more
+modern Linux systems, in particular on Ubuntu 18.04. He has
+added a README.md file in the sysv folder with more information.
 
-NOTE: There is a disconnect between Unix and the `sysv` driver. After
-exporting a filesystem image from a volume image, you must run `s4fsck`
-on it to rebuild the free list. Otherwise, Linux will think there's
-no free space.  After importing such a filesystem, Unix runs a longer
-`fsck` than usual, but things work OK.  I have not tried to track down
-the problem; help with this would be welcome.
-
-Note also that when creating files on a mounted System V filesystem,
+Note that when creating files on a mounted System V filesystem,
 Linux will *not* truncate file names for you; you must keep
 filenames to 14 characters or less.
-
-A fork of my fork is at 
-https://github.com/arnoldrobbins/s4-3b1-pc7300/ that the sysv driver has been
-updated to work with Ubuntu 18.04.
 
 
 Rest of this is the original readme.

--- a/s4d.c
+++ b/s4d.c
@@ -1128,7 +1128,7 @@ s4err s4_filsys_show( s4_filsys *xfs )
 {
   struct s4_dfilsys *fs = &xfs->super.super;
 
-  if( S4_FsMAGIC_BE == fs->s_magic )
+  if( S4_FsMAGIC_LE == fs->s_magic )
     {
       printf("FS is swapped\n");
       return s4_badmagic;
@@ -1239,7 +1239,7 @@ void s4_fsu_swap( s4_fsu *fsu, int btype )
         for( i = 0; i < 4; i++ )
           fs->s_vinfo[i] = s4swaph( fs->s_vinfo[i] );
 
-        fs->s_time   = s4swapi( fs->s_tfree );
+        fs->s_time   = s4swapi( fs->s_time );
         fs->s_tfree  = s4swapi( fs->s_tfree );
         fs->s_tinode = s4swaph( fs->s_tinode );
         fs->s_type   = s4swapi( fs->s_type );

--- a/s4d.c
+++ b/s4d.c
@@ -1292,7 +1292,7 @@ void s4_fsu_swap( s4_fsu *fsu, int btype )
 
     case s4b_free:
       {
-        fsu->free.df_nfree = s4swaph( fsu->free.df_nfree );        
+        fsu->free.df_nfree = s4swapi( fsu->free.df_nfree );
 
         for( i = 0; i < S4_NICFREE; i++ )
             fsu->free.df_free[ i ] = s4swapi( fsu->free.df_free[ i ] );        
@@ -1424,8 +1424,8 @@ void s4_fsu_show( s4_fsu *fsu, int btype )
         if( S4_FsMAGIC != fs->s_magic )
           return;
 
-        printf("  FREE BLOCKS:");
-        for( i = 0; i < S4_NICFREE; i++ )
+        printf("  %d FREE BLOCKS:", fs->s_nfree);
+        for( i = 0; i < S4_NICFREE && i < fs->s_nfree; i++ )
           {
             if(  !(i % 8) )
               printf("\n    ");
@@ -1437,8 +1437,8 @@ void s4_fsu_show( s4_fsu *fsu, int btype )
           }
         printf("\n");
         
-        printf("  FREE INO:");
-        for( i = 0; i < S4_NICINOD; i++ )
+        printf("  %d FREE INO:", fs->s_ninode);
+        for( i = 0; i < S4_NICINOD && i < fs->s_ninode; i++ )
           {
             if( !(i % 8) )
               printf("\n    ");
@@ -1447,7 +1447,7 @@ void s4_fsu_show( s4_fsu *fsu, int btype )
             if( x < 0 || x > 20000 )
               break;
           }
-        printf("  (%d)\n", i);
+        printf("\n");
 
         printf("  DISKINFO:\n");
         for( i = 0; i < 4; i++ )

--- a/s4d.h
+++ b/s4d.h
@@ -69,7 +69,7 @@
 #define S4_HD_FS_PNUM     (2)
 
 /* ---------------------------------------------------------------- */
-/* replacing <sys/params.h */
+/* replacing sys/param.h */
 
 #define S4_ROOTINO      2
 #define	S4_NICFREE	50    /* number of superblock free blocks */
@@ -85,7 +85,7 @@ typedef int32_t    s4_daddr;
 typedef uint16_t   s4_ino;
 typedef int32_t    s4_off;
 typedef int32_t    s4_time;
-typedef int32_t    s4_dev;
+typedef int16_t    s4_dev;
 
 /* ---------------------------------------------------------------- */
 /* replace sys/gdisk.h */
@@ -138,7 +138,7 @@ struct s4_bbe {
                                    within the cylinder cyl */
   uint16_t	altblk;		/* track number of alternate */
   uint16_t	nxtind;		/* index into the cell array for next bad block
-r0st				   cell for this cylinder */
+				   cell for this cylinder */
 };
 
 #define S4_MNAMSZ	40		/* max length of name including null terminator */
@@ -156,8 +156,8 @@ struct s4_resdes {		/* reserved area special files */
 
 /*	volume home block on disk	*/
 struct  s4_vhbd {
-	uint	magic;		/* S4 disk format code */
-	int	chksum;		/* adjustment so that the 32 bit sum starting
+	uint32_t	magic;		/* S4 disk format code */
+	int32_t		chksum;		/* adjustment so that the 32 bit sum starting
 				   from magic for 512 bytes sums to -1 */
 	struct s4_dswprt dsk;	/* specific description of this disk */
 	struct s4_partit partab[S4_MAXSLICE];	/* partition table */
@@ -172,11 +172,11 @@ struct  s4_vhbd {
 	char	fpulled;	/* dismounted last time? */
         char    pad;		/* dbrower 2016 */
 
-        /* this 8 slices * 40 = 500 bytes!? */
+        /* this 16 slices * 40 = 640 bytes! */
 	struct	s4_mntnam mntname[S4_MAXSLICE];	/* names for auto mounting.
 			  		   null string means no auto mount */
-	int	time;		/* time last came on line */
-	short	cpioMagic,	/* for cpio backup, restore	*/
+	int32_t	time;		/* time last came on line */
+	int16_t	cpioMagic,	/* for cpio backup, restore	*/
 		setMagic,
 		cpioVol;
 } __attribute__((__packed__));
@@ -240,16 +240,16 @@ struct	s4_dfilsys
 {
 	uint16_t	 s_isize;	/* size in blocks of i-list */
 	s4_daddr s_fsize;	/* size in blocks of entire volume */
-	short	 s_nfree;	/* number of addresses in s_free */
+	int16_t	 s_nfree;	/* number of addresses in s_free */
 	s4_daddr s_free[S4_NICFREE];	/* free block list */
-	short	 s_ninode;	/* number of i-nodes in s_inode */
+	int16_t	 s_ninode;	/* number of i-nodes in s_inode */
 	s4_ino	 s_inode[S4_NICINOD];	/* free i-node list */
 	char	 s_flock;	/* lock during free list manipulation */
 	char	 s_ilock;	/* lock during i-list manipulation */
 	char  	 s_fmod; 	/* super block modified flag */
 	char	 s_ronly;	/* mounted read-only flag */
-        int32_t	 s_time; 	/* last super block update */
-	short	 s_vinfo[4];	/* device information */
+	s4_time	 s_time; 	/* last super block update */
+	int16_t	 s_vinfo[4];	/* device information */
 	s4_daddr s_tfree;	/* total free blocks */
 	s4_ino	 s_tinode;	/* total free inodes */
 	char	 s_fname[6];	/* file system name */
@@ -261,8 +261,8 @@ struct	s4_dfilsys
 } __attribute__((__packed__)) ;
 
 #define	S4_FsMAGIC     0xfd187e20	/* s_magic number */
-#define S4_FsMAGIC_LE  S4_FsMAGIC       /* layed out in order */
-#define S4_FsMAGIC_BE  0x207e18fd       /* layed out reverse  */
+#define S4_FsMAGIC_BE  S4_FsMAGIC       /* layed out in order */
+#define S4_FsMAGIC_LE  0x207e18fd       /* layed out reverse  */
 
 #define	S4_Fs1b	1	/* 512 byte block */
 #define	S4_Fs2b	2	/* 1024 byte block */
@@ -303,7 +303,7 @@ struct	s4_dfilsys
 
 struct	s4_fblk
 {
-	int        df_nfree;
+	int32_t    df_nfree;
 	s4_daddr   df_free[S4_NICFREE];
 };
 
@@ -355,16 +355,16 @@ struct	s4_direct
 /* replace sys/sysmacros.h */
 /* inumber to disk address */
 #ifdef S4_INOSHIFT
-#define	itod(x)	(s4_daddr)(((unsigned)x+(2*S4_INOPB-1))>>S4_INOSHIFT)
+#define	itod(x)	(s4_daddr)(((uint32_t)x+(2*S4_INOPB-1))>>S4_INOSHIFT)
 #else
-#define	itod(x)	(s4_daddr)(((unsigned)x+(2*S4_INOPB-1))/S4_INOPB)
+#define	itod(x)	(s4_daddr)(((uint32_t)x+(2*S4_INOPB-1))/S4_INOPB)
 #endif
 
 /* inumber to disk offset */
 #ifdef S4_INOSHIFT
-#define	itoo(x)	(int)(((unsigned)x+(2*S4_INOPB-1))&(S4_INOPB-1))
+#define	itoo(x)	(s4_off)(((uint32_t)x+(2*S4_INOPB-1))&(S4_INOPB-1))
 #else
-#define	itoo(x)	(int)(((unsigned)x+(2*S4_INOPB-1))%S4_INOPB)
+#define	itoo(x)	(s4_off)(((uint32_t)x+(2*S4_INOPB-1))%S4_INOPB)
 #endif
 
 
@@ -427,7 +427,7 @@ typedef enum
 /* raw filesystem block sizing */
 
 #define S4_NDIRECT (S4_BSIZE/sizeof(struct s4_direct))
-#define S4_SPERB   (S4_BSIZE/sizeof(short))
+#define S4_SPERB   (S4_BSIZE/sizeof(int16_t))
 #define S4_NBB     (512/sizeof(struct s4_bbe))
 
 /* All the blocks we know about in one union */
@@ -444,7 +444,7 @@ typedef union
     /* from the file system */
     struct s4_dinode  dino[ S4_INOPB ];
     struct s4_direct  dir[ S4_NDIRECT ];
-    short             links[ S4_SPERB ];
+    int16_t           links[ S4_SPERB ];
     s4_daddr          indir[ S4_NINDIR ];
     struct s4_dfilsys super;
     struct s4_fblk    free;

--- a/s4date.c
+++ b/s4date.c
@@ -170,10 +170,20 @@ int	**argv;
 		if (localtime(&timbuf)->tm_isdst)
 			timbuf += -1*60*60;
 
+#ifdef __linux__
+		struct timespec ts;
+		ts.tv_nsec = 0;
+		ts.tv_sec = timbuf;
+		if (clock_settime(CLOCK_REALTIME, &ts) < 0) {
+			tfailed++;
+			(void) fprintf(stderr, "date: no permission\n");
+		}
+#else
 		if(stime(&timbuf) < 0) {
 			tfailed++;
 			(void) fprintf(stderr, "date: no permission\n");
 		} 
+#endif
                 /* s4date: no wtmp/utmp access */
 	}
 	if (tfailed==0)

--- a/sysv/README.md
+++ b/sysv/README.md
@@ -10,6 +10,10 @@ Check that there isn't a `sysv` module active:
 
     lsmod | grep sysv
 
+If there is, this can be removed with:
+
+    sudo rmmod sysv
+
 Insert your newly-compiled module:
 
     sudo insmod ./sysv.ko
@@ -17,10 +21,6 @@ Insert your newly-compiled module:
 Export a filesystem image from a volume image:
 
     s4export -i hd.img -o hd.fs
-
-Run it through `s4fsck` to repair the free list:
-
-    s4fsck hd.fs
 
 Now you can mount the image:
 
@@ -33,7 +33,9 @@ When done, unmount the filesystem:
     sudo umount /mnt
 
 Use `s4import` to pull the modified filesystem back in to the
-volume image.
+volume image:
+
+    s4import -i hd.fs -o hd.img
 
 #### Last Modified:
-Thu Dec 10 20:21:20 IST 2020
+Tue 19 Jan 2021 11:38:21 PM EST


### PR DESCRIPTION
Hi David.  Here are a few fixes after reviewing the code. The major fix is for the free list. In the superblock, the number of free list entries is a int16. But then in the free blocks, the first int32 is the number of entries for that free block chain. But the code was treating it as a int16. So basically the free list ended up being truncated to only the number of entries in the superblock -- never progressing down through the full chain of free blocks. 

Never thought I'd end up investigating something in the sysv file system -- lol.

If you have any questions, just let me know.

I also updated the README's as they were a bit confusing as they merged in some of Arnold's text which was appropriate for his fork but confusing in yours.  I think it's good now.

   Jesse
